### PR TITLE
Update Form Compenents For Back-end Forms

### DIFF
--- a/resources/views/backend/includes/components/form/button.blade.php
+++ b/resources/views/backend/includes/components/form/button.blade.php
@@ -1,7 +1,9 @@
 <div class="form-group row">
     @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label') }}
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label') }}
+        </div>
     @endif
     <div class="col-md-10">
         {{ html()->button($text, $type ?? 'button')
@@ -14,4 +16,3 @@
         @endif
     </div><!--col-->
 </div><!--form-group-->
-

--- a/resources/views/backend/includes/components/form/checkbox.blade.php
+++ b/resources/views/backend/includes/components/form/checkbox.blade.php
@@ -1,8 +1,9 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
-    @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
-                ->for($name) }}
+@if (isset($label))
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label') }}
+        </div>
     @endif
     <div class="col-md-10">
         <div class="checkbox">

--- a/resources/views/backend/includes/components/form/date.blade.php
+++ b/resources/views/backend/includes/components/form/date.blade.php
@@ -1,8 +1,10 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
     @if (isset($label))
+        <div class="col-md-2">
         {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
+                ->class('form-control-label')
                 ->for($name) }}
+        </div>
     @endif
     <div class="col-md-10">
         <div id="{{ $name }}_group" class="input-group date" data-target-input="nearest">

--- a/resources/views/backend/includes/components/form/input.blade.php
+++ b/resources/views/backend/includes/components/form/input.blade.php
@@ -1,8 +1,10 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
     @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
-                ->for($name) }}
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label')
+                    ->for($name) }}
+        </div>
     @endif
     <div class="col-md-10">
         {{ html()->input(

--- a/resources/views/backend/includes/components/form/multiselect.blade.php
+++ b/resources/views/backend/includes/components/form/multiselect.blade.php
@@ -1,8 +1,10 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
     @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
-                ->for($name) }}
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label')
+                    ->for($name) }}
+        </div>
     @endif
 
     <div class="col-md-10">

--- a/resources/views/backend/includes/components/form/richtext.blade.php
+++ b/resources/views/backend/includes/components/form/richtext.blade.php
@@ -1,8 +1,10 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
     @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
-                ->for($name) }}
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label')
+                    ->for($name) }}
+        </div>
     @endif
     <div class="col-md-10">
         {{ html()->textarea($name, old($name) ?: ($object->{$name} ?? ''))

--- a/resources/views/backend/includes/components/form/select.blade.php
+++ b/resources/views/backend/includes/components/form/select.blade.php
@@ -1,8 +1,10 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
     @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
-                ->for($name) }}
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label')
+                    ->for($name) }}
+        </div>
     @endif
     <div class="col-md-10">
         {{ html()->select(

--- a/resources/views/backend/includes/components/form/textarea.blade.php
+++ b/resources/views/backend/includes/components/form/textarea.blade.php
@@ -1,8 +1,10 @@
 <div class="form-group{{ $errors->has($name) ? ' has-error' : '' }} row">
     @if (isset($label))
-        {{ html()->label($label)
-                ->class('col-md-2 form-control-label')
-                ->for($name) }}
+        <div class="col-md-2">
+            {{ html()->label($label)
+                    ->class('form-control-label')
+                    ->for($name) }}
+        </div>
     @endif
     <div class="col-md-10">
         {{ html()->textarea($name, old($name) ?: ($object->{$name} ?? ''))

--- a/resources/views/frontend/opportunity/internship/private/fields.blade.php
+++ b/resources/views/frontend/opportunity/internship/private/fields.blade.php
@@ -1,7 +1,6 @@
 
             <div class="row mt-4">
                 <div class="col">
-
                     <div class="form-group row">
                         <label class="col-md-2 form-control-label">[Required Fields *]</label>
 


### PR DESCRIPTION
Applied the same fix used on the front-end form components to our back-end form components - removing column classes from the labels themselves and wrapping the labels in standard Bootstrap columns. This helps to prevent users from accidentally setting focus on a form field when clicking on whitespace (which was actually very large form labels).