### PR TITLE
Add File Upload fieldgroup to opportunity Create forms

### DIFF
--- a/resources/views/backend/opportunity/internship/attachment/add.blade.php
+++ b/resources/views/backend/opportunity/internship/attachment/add.blade.php
@@ -34,7 +34,7 @@
                         <div class="col">
 
                             <!-- File Upload Field -->
-                            @component('frontend.includes.coreui.components.form.input', [
+                            @component('backend.includes.components.form.input', [
                                 'type'        => 'file',
                                 'name'        => 'file_attachment',
                                 'label'       => 'File Attachment',

--- a/resources/views/backend/opportunity/internship/create.blade.php
+++ b/resources/views/backend/opportunity/internship/create.blade.php
@@ -3,7 +3,7 @@
 @section ('title', __('labels.backend.opportunity.internships.management') . ' | ' . __('labels.backend.opportunity.internships.create'))
 
 @section('content')
-{{ html()->form('POST', route('admin.opportunity.internship.store'))->id('internship-form')->class('form-horizontal')->open() }}
+{{ html()->form('POST', route('admin.opportunity.internship.store'))->acceptsFiles()->id('internship-form')->class('form-horizontal')->open() }}
 
     <div class="card">
         <div class="card-body">

--- a/resources/views/backend/opportunity/internship/fields.blade.php
+++ b/resources/views/backend/opportunity/internship/fields.blade.php
@@ -386,6 +386,67 @@
         </div><!--card-body-->
     </div><!--card-->
 
+    @if ('create' === $formMode)
+    <div class="card">
+        <div class="card-body">
+            <div class="row">
+                <div class="col-sm-5">
+                    <h4 class="card-title mb-0">
+                        Upload Attachment
+                    </h4>
+                </div><!--col-->
+            </div><!--row-->
+
+            <hr />
+
+            <div class="row mt-4">
+                <div class="col">
+                    <!-- File Upload Field -->
+                    @component('backend.includes.components.form.input', [
+                        'type'        => 'file',
+                        'name'        => 'file_attachment',
+                        'label'       => 'File Attachment',
+                    ])@endcomponent
+
+                    <div class="form-group row">
+                        {{ html()->label('Visibility *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_status') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_status',
+                                $attachmentStatuses,
+                                old('attachment_status') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment visibility...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+
+                    <div class="form-group row">
+                        {{ html()->label('Attachment Type *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_type') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_type',
+                                $attachmentTypes,
+                                old('attachment_type') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment type...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+                </div><!--col-->
+            </div><!--row-->
+        </div><!--card-body-->
+    </div><!--card-->
+@endif
+
     <div class="card">
         <div class="card-body">
             <div class="row mt-4">

--- a/resources/views/backend/opportunity/internship/show/tabs/overview.blade.php
+++ b/resources/views/backend/opportunity/internship/show/tabs/overview.blade.php
@@ -1,7 +1,6 @@
 <div class="col">
     <ul class="list-group">
         <li class="list-group-item"><span style="float: left; width: 200px;"><b>Status:</b></span> {{ ucwords($internship->status->name ?? '') }}</li>
-        <li class="list-group-item"><span style="float: left; width: 200px;"><b>Review Status:</b></span> {{ ucwords($internship->reviewStatus->name ?? '') }}</li>
         <li class="list-group-item"><span style="float: left; width: 200px;"><b>Internship Starts:</b></span> {{ isset($internship->opportunity_start_at) ? $internship->opportunity_start_at->toFormattedDateString() : '' }} {{ isset($internship->opportunity_start_at) ? '(' . $internship->opportunity_start_at->diffForHumans() . ')' : '' }}</li>
         <li class="list-group-item"><span style="float: left; width: 200px;"><b>Internship Ends:</b></span> {{ isset($internship->opportunity_end_at) ? $internship->opportunity_end_at->toFormattedDateString() : '' }} {{ isset($internship->opportunity_end_at) ? '(' . $internship->opportunity_end_at->diffForHumans() . ')' : '' }}</li>
         <li class="list-group-item"><span style="float: left; width: 200px;"><b>Listing Starts:</b></span> {{ isset($internship->listing_start_at) ? $internship->listing_start_at->toFormattedDateString() : '' }} {{ isset($internship->listing_start_at) ? '(' . $internship->listing_start_at->diffForHumans() . ')' : '' }}</li>

--- a/resources/views/backend/opportunity/project/attachment/add.blade.php
+++ b/resources/views/backend/opportunity/project/attachment/add.blade.php
@@ -34,7 +34,7 @@
                         <div class="col">
 
                             <!-- File Upload Field -->
-                            @component('frontend.includes.coreui.components.form.input', [
+                            @component('backend.includes.components.form.input', [
                                 'type'        => 'file',
                                 'name'        => 'file_attachment',
                                 'label'       => 'File Attachment',

--- a/resources/views/backend/opportunity/project/create.blade.php
+++ b/resources/views/backend/opportunity/project/create.blade.php
@@ -3,7 +3,7 @@
 @section ('title', __('labels.backend.opportunity.projects.management') . ' | ' . __('labels.backend.opportunity.projects.create'))
 
 @section('content')
-{{ html()->form('POST', route('admin.opportunity.project.store'))->id('project-form')->class('form-horizontal')->open() }}
+{{ html()->form('POST', route('admin.opportunity.project.store'))->acceptsFiles()->id('project-form')->class('form-horizontal')->open() }}
 
     <div class="card">
         <div class="card-body">

--- a/resources/views/backend/opportunity/project/fields.blade.php
+++ b/resources/views/backend/opportunity/project/fields.blade.php
@@ -400,6 +400,67 @@
         </div><!--card-body-->
     </div><!--card-->
 
+@if ('create' === $formMode)
+    <div class="card">
+        <div class="card-body">
+            <div class="row">
+                <div class="col-sm-5">
+                    <h4 class="card-title mb-0">
+                        Upload Attachment
+                    </h4>
+                </div><!--col-->
+            </div><!--row-->
+
+            <hr />
+
+            <div class="row mt-4">
+                <div class="col">
+                    <!-- File Upload Field -->
+                    @component('backend.includes.components.form.input', [
+                        'type'        => 'file',
+                        'name'        => 'file_attachment',
+                        'label'       => 'File Attachment',
+                    ])@endcomponent
+
+                    <div class="form-group row">
+                        {{ html()->label('Visibility *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_status') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_status',
+                                $attachmentStatuses,
+                                old('attachment_status') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment visibility...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+
+                    <div class="form-group row">
+                        {{ html()->label('Attachment Type *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_type') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_type',
+                                $attachmentTypes,
+                                old('attachment_type') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment type...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+                </div><!--col-->
+            </div><!--row-->
+        </div><!--card-body-->
+    </div><!--card-->
+@endif
+
     <div class="card">
         <div class="card-body">
             <div class="row mt-4">

--- a/resources/views/frontend/opportunity/internship/private/create.blade.php
+++ b/resources/views/frontend/opportunity/internship/private/create.blade.php
@@ -3,7 +3,7 @@
 @section ('title', 'Internship | Create internship listing')
 
 @section('content')
-{{ html()->form('POST', route('frontend.opportunity.internship.private.store'))->class('form-horizontal')->open() }}
+{{ html()->form('POST', route('frontend.opportunity.internship.private.store'))->acceptsFiles()->class('form-horizontal')->open() }}
 
     <div class="card">
         <div class="card-body">

--- a/resources/views/frontend/opportunity/internship/private/fields.blade.php
+++ b/resources/views/frontend/opportunity/internship/private/fields.blade.php
@@ -385,6 +385,67 @@
         </div><!--card-body-->
     </div><!--card-->
 
+@if ('create' === $formMode)
+    <div class="card">
+        <div class="card-body">
+            <div class="row">
+                <div class="col-sm-5">
+                    <h4 class="card-title mb-0">
+                        Upload Attachment
+                    </h4>
+                </div><!--col-->
+            </div><!--row-->
+
+            <hr />
+
+            <div class="row mt-4">
+                <div class="col">
+                    <!-- File Upload Field -->
+                    @component('backend.includes.components.form.input', [
+                        'type'        => 'file',
+                        'name'        => 'file_attachment',
+                        'label'       => 'File Attachment',
+                    ])@endcomponent
+
+                    <div class="form-group row">
+                        {{ html()->label('Visibility *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_status') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_status',
+                                $attachmentStatuses,
+                                old('attachment_status') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment visibility...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+
+                    <div class="form-group row">
+                        {{ html()->label('Attachment Type *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_type') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_type',
+                                $attachmentTypes,
+                                old('attachment_type') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment type...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+                </div><!--col-->
+            </div><!--row-->
+        </div><!--card-body-->
+    </div><!--card-->
+@endif
+
     <div class="card">
         <div class="card-body">
             <div class="row mt-4">

--- a/resources/views/frontend/opportunity/project/private/create.blade.php
+++ b/resources/views/frontend/opportunity/project/private/create.blade.php
@@ -3,7 +3,7 @@
 @section ('title', 'Project | Create project listing')
 
 @section('content')
-{{ html()->form('POST', route('frontend.opportunity.project.private.store'))->id('project-form')->class('form-horizontal')->open() }}
+{{ html()->form('POST', route('frontend.opportunity.project.private.store'))->acceptsFiles()->id('project-form')->class('form-horizontal')->open() }}
 
     <div class="card">
         <div class="card-body">

--- a/resources/views/frontend/opportunity/project/private/fields.blade.php
+++ b/resources/views/frontend/opportunity/project/private/fields.blade.php
@@ -348,6 +348,67 @@
         </div><!--card-body-->
     </div><!--card-->
 
+@if ('create' === $formMode)
+    <div class="card">
+        <div class="card-body">
+            <div class="row">
+                <div class="col-sm-5">
+                    <h4 class="card-title mb-0">
+                        Upload Attachment
+                    </h4>
+                </div><!--col-->
+            </div><!--row-->
+
+            <hr />
+
+            <div class="row mt-4">
+                <div class="col">
+                    <!-- File Upload Field -->
+                    @component('backend.includes.components.form.input', [
+                        'type'        => 'file',
+                        'name'        => 'file_attachment',
+                        'label'       => 'File Attachment',
+                    ])@endcomponent
+
+                    <div class="form-group row">
+                        {{ html()->label('Visibility *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_status') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_status',
+                                $attachmentStatuses,
+                                old('attachment_status') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment visibility...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+
+                    <div class="form-group row">
+                        {{ html()->label('Attachment Type *')
+                                ->class('col-md-2 form-control-label')
+                                ->for('attachment_type') }}
+                        <div class="col-md-10">
+                            {{ html()->select(
+                                'attachment_type',
+                                $attachmentTypes,
+                                old('attachment_type') ?: null
+                            )
+                                ->class('form-control selectize-single')
+                                ->placeholder('Select attachment type...')
+                                ->attribute('required')
+                            }}
+                        </div><!--col-->
+                    </div><!--form-group-->
+                </div><!--col-->
+            </div><!--row-->
+        </div><!--card-body-->
+    </div><!--card-->
+@endif
+
     <div class="card">
         <div class="card-body">
             <div class="row">


### PR DESCRIPTION
Only adding the file upload to the Create forms, so we can enable a single file upload (the simplest solution). This allows a single file upload to be added during the creation of a new Project or Internship. 

Attachment editing (and uploading additional files) must then be handled on the Attachments tab when viewing the full opportunity.