### PR TITLE
Add check for empty $note->user property to prevent Server 500 errors

### DIFF
--- a/resources/views/backend/opportunity/internship/show/tabs/notes.blade.php
+++ b/resources/views/backend/opportunity/internship/show/tabs/notes.blade.php
@@ -15,7 +15,7 @@
                 <table class="table table-hover">
                     @foreach($internship->notes as $note)
                         <tr>
-                            <th class="w-25">{{ ucwords($note->user->name) . ': ' . $note->created_at->toFormattedDateString() }}</th>
+                            <th class="w-25">{{ !empty($note->user) ? ucwords($note->user->full_name) . ': ' . $note->created_at->toFormattedDateString() : '' }}</th>
                             <td>@markdown($note->body)</td>
                         </tr>
                     @endforeach

--- a/resources/views/backend/opportunity/project/show/tabs/notes.blade.php
+++ b/resources/views/backend/opportunity/project/show/tabs/notes.blade.php
@@ -15,7 +15,7 @@
                 <table class="table table-hover">
                     @foreach($project->notes as $note)
                         <tr>
-                            <th class="w-25">{{ ucwords($note->user->name) . ': ' . $note->created_at->toFormattedDateString() }}</th>
+                            <th class="w-25">{{ !empty($note->user) ? ucwords($note->user->full_name) . ': ' . $note->created_at->toFormattedDateString() : '' }}</th>
                             <td>@markdown($note->body)</td>
                         </tr>
                     @endforeach

--- a/resources/views/frontend/opportunity/internship/private/show/tabs/notes.blade.php
+++ b/resources/views/frontend/opportunity/internship/private/show/tabs/notes.blade.php
@@ -17,7 +17,7 @@
                 <table class="table table-hover">
                     @foreach($internship->notes as $note)
                         <tr>
-                            <th class="w-25">{{ ucwords($note->user->name) . ': ' . $note->created_at->toFormattedDateString() }}</th>
+                            <th class="w-25">{{ !empty($note->user) ? ucwords($note->user->full_name) . ': ' . $note->created_at->toFormattedDateString() : '' }}</th>
                             <td>@markdown($note->body)</td>
                         </tr>
                     @endforeach

--- a/resources/views/frontend/opportunity/project/private/show/tabs/notes.blade.php
+++ b/resources/views/frontend/opportunity/project/private/show/tabs/notes.blade.php
@@ -17,7 +17,7 @@
                 <table class="table table-hover">
                     @foreach($project->notes as $note)
                         <tr>
-                            <th class="w-25">{{ ucwords($note->user->name) . ': ' . $note->created_at->toFormattedDateString() }}</th>
+                            <th class="w-25">{{ !empty($note->user) ? ucwords($note->user->full_name) . ': ' . $note->created_at->toFormattedDateString() : '' }}</th>
                             <td>@markdown($note->body)</td>
                         </tr>
                     @endforeach


### PR DESCRIPTION
Prevents import oddities from old notes causing 500 errors. When loading a project to view in the Dashboard, the Notes tab template errored because when attempting to render the name of the user associated with specific legacy notes records, those notes had no user info to access. This is solely an issue with these legacy notes, so this PR simply adds a null check for the user property.