### PR TITLE
Show Urgent Projects and Internships at Top of Tables

### DIFF
--- a/resources/views/frontend/opportunity/internship/public/index.blade.php
+++ b/resources/views/frontend/opportunity/internship/public/index.blade.php
@@ -85,13 +85,13 @@
                                 @endforeach
                             </td>
                             <td>
-                                @foreach ($internship->affiliations as $aff)
-                                    {{$aff->name}}
+                                @foreach ($internship->affiliations as $affiliation)
+                                    {{$affiliation->name}}
                                 @endforeach
                             </td>
                             <td>
-                                @foreach ($internship->affiliations as $aff)
-                                    @if($aff->slug == 'urgent')
+                                @foreach ($internship->affiliations as $affiliation)
+                                    @if($affiliation->slug == 'urgent')
                                         1
                                         @break
                                     @endif

--- a/resources/views/frontend/opportunity/internship/public/index.blade.php
+++ b/resources/views/frontend/opportunity/internship/public/index.blade.php
@@ -16,6 +16,8 @@
                         <th>Keywords</th>
                         <th data-priority="2">Organization</th>
                         <th data-priority="4">Availability</th>
+                        <th>Availability Name</th>
+                        <th>Order</th>
                         <th data-priority="4">City</th>
                         <th data-priority="1">Apply By</th>
                     </tr>
@@ -80,6 +82,19 @@
                                     </div>
                                 </span>
                                     @endunless
+                                @endforeach
+                            </td>
+                            <td>
+                                @foreach ($internship->affiliations as $aff)
+                                    {{$aff->name}}
+                                @endforeach
+                            </td>
+                            <td>
+                                @foreach ($internship->affiliations as $aff)
+                                    @if($aff->slug == 'urgent')
+                                        1
+                                        @break
+                                    @endif
                                 @endforeach
                             </td>
                             <td>
@@ -192,7 +207,7 @@
                 "columnDefs": [
                   {
                     "visible": false,
-                    "targets": [2,3]
+                    "targets": [2,3,6,7]
                   },
                   {
                     "className": "control",
@@ -204,7 +219,8 @@
                     "targets": 1
                   }
                 ],
-                "order": [ 5, 'asc' ],
+                /* order by urgent first, then by application date */
+                "order": [ [7, 'desc'], [9, 'asc'] ],
                 "lengthMenu": [ [25, 50, 100], [25, 50, 100] ]
             });
             $('[data-toggle="tooltip"]').tooltip();

--- a/resources/views/frontend/opportunity/project/public/active/index.blade.php
+++ b/resources/views/frontend/opportunity/project/public/active/index.blade.php
@@ -80,13 +80,13 @@
                             @endforeach
                         </td>
                         <td>
-                            @foreach ($project->affiliations as $aff)
-                                {{$aff->name}}
+                            @foreach ($project->affiliations as $affiliation)
+                                {{$affiliation->name}}
                             @endforeach
                         </td>
                         <td>
-                            @foreach ($project->affiliations as $aff)
-                                @if($aff->slug == 'urgent')
+                            @foreach ($project->affiliations as $affiliation)
+                                @if($affiliation->slug == 'urgent')
                                     1
                                     @break
                                 @endif

--- a/resources/views/frontend/opportunity/project/public/active/index.blade.php
+++ b/resources/views/frontend/opportunity/project/public/active/index.blade.php
@@ -16,6 +16,8 @@
                     <th>Category</th>
                     <th>Keywords</th>
                     <th data-priority="4">Availability</th>
+                    <th>Availability Name</th>
+                    <th>Order</th>
                     <th data-priority="4">City</th>
                     <th data-priority="2">Begins</th>
                     <th data-priority="3">Ends</th>
@@ -75,6 +77,19 @@
                                     </div>
                                 </span>
                                 @endunless
+                            @endforeach
+                        </td>
+                        <td>
+                            @foreach ($project->affiliations as $aff)
+                                {{$aff->name}}
+                            @endforeach
+                        </td>
+                        <td>
+                            @foreach ($project->affiliations as $aff)
+                                @if($aff->slug == 'urgent')
+                                    1
+                                    @break
+                                @endif
                             @endforeach
                         </td>
                         <td>
@@ -189,7 +204,7 @@
                 "columnDefs": [
                   {
                     "visible": false,
-                    "targets": [2,3]
+                    "targets": [2,3,5,6]
                   },
                   {
                     "className": "control",
@@ -201,7 +216,7 @@
                     "targets": 1
                   }
                 ],
-                "order": [ 5, 'asc' ],
+                "order": [[ 6, 'desc' ], [10, 'asc']],
                 "lengthMenu": [ [25, 50, 100], [25, 50, 100] ]
             });
             $('[data-toggle="tooltip"]').tooltip();

--- a/resources/views/frontend/opportunity/project/public/completed/index.blade.php
+++ b/resources/views/frontend/opportunity/project/public/completed/index.blade.php
@@ -13,13 +13,18 @@
                 <tr>
                   <th>More</th>
                   <th>Name</th>
-                  <th>Category</th>
-                  <th>Keywords</th>
+                  <th data-priority="2">Category</th>
+                  <th data-priority="4">Keywords</th>
+                  <th data-priority="3">Ends</th>
+                  <!--
                   <th data-priority="4">Availability</th>
+                  <th>Availability Name</th>
+                  <th>Order</th>
                   <th data-priority="4">City</th>
                   <th data-priority="2">Begins</th>
                   <th data-priority="3">Ends</th>
                   <th data-priority="1">Apply By</th>
+                  -->
                 </tr>
             </thead>
             <tbody>
@@ -30,7 +35,7 @@
                         <td>
                           @if ($project->categories->count())
                             @foreach($project->categories as $category)
-                              {{ ucwords($category->name) }}
+                              <span class="label label-default">{{ ucwords($category->name) }}</span>
                             @endforeach
                           @endif
                         </td>
@@ -41,6 +46,7 @@
                             @endforeach
                           @endif
                         </td>
+                        <!--
                         <td class="icon-column">
                             @foreach ($project->affiliations as $icon)
                                 @unless(empty($icon->frontend_fa_icon))
@@ -56,6 +62,19 @@
                             @endforeach
                         </td>
                         <td>
+                            @foreach ($project->affiliations as $aff)
+                                {{$aff->name}}
+                            @endforeach
+                        </td>
+                        <td>
+                            @foreach ($project->affiliations as $aff)
+                                @if($aff->slug == 'urgent')
+                                    1
+                                    @break
+                                @endif
+                            @endforeach
+                        </td>
+                        <td>
                             @if ($project->addresses->count())
                                 @foreach ($project->addresses as $address)
                                     {{ ucwords($address->city) }}
@@ -66,6 +85,7 @@
                         </td>
                         <td>{{ null !== $project->opportunity_start_at ? $project->opportunity_start_at->toDateString() : null }}</td>
                         <td>{{ null !== $project->opportunity_end_at ? $project->opportunity_end_at->toDateString() : null }}</td>
+                        -->
                         <td>{{
                               null != $project->application_deadline_text
                                 ? $project->application_deadline_text
@@ -166,7 +186,7 @@
               },
               "columnDefs": [
                   {
-                    "targets": [2,3],
+                    "targets": [3],
                     "visible": false
                   },
                   {
@@ -179,7 +199,8 @@
                     "targets": 1
                   }
                 ],
-                "order": [ 8, 'asc' ],
+                /* sorted by closing date; ignoring urgent */
+                "order": [ 4, 'desc' ],
                 "lengthMenu": [ [25, 50, 100], [25, 50, 100] ],
           } );
         } ) ;

--- a/resources/views/frontend/opportunity/project/public/completed/index.blade.php
+++ b/resources/views/frontend/opportunity/project/public/completed/index.blade.php
@@ -62,13 +62,13 @@
                             @endforeach
                         </td>
                         <td>
-                            @foreach ($project->affiliations as $aff)
-                                {{$aff->name}}
+                            @foreach ($project->affiliations as $affiliation)
+                                {{$affiliation->name}}
                             @endforeach
                         </td>
                         <td>
-                            @foreach ($project->affiliations as $aff)
-                                @if($aff->slug == 'urgent')
+                            @foreach ($project->affiliations as $affiliation)
+                                @if($affiliation->slug == 'urgent')
                                     1
                                     @break
                                 @endif


### PR DESCRIPTION
Updated the three public-facing DataTables pages:

* Current Projects
* Past Projects
* Internships

With the following changes:

* Added a hidden column specifically for 'urgent' internships and projects. If something has the Urgent icon, it will also have a '1' in this hidden column. We then sort by this column first, which puts the urgent items at the top of the table
* Added another hidden column holding the name value for each availability icon, which allows the DataTables search function to include those things when searching (i.e. you can now type 'urgent', or 'graduate' and get a filtered table)
* For _Past_ Projects only, removed several columns that didn't make sense in a past project (when it opens, when it closed, etc.) and made the 'Category' column visible.

Note: just in case we change our minds about this, on the Past Projects page I only commented out the parts of the table we didn't want, rather than deleting them.