### PR TITLE
Fix Page Title for Past Projects

### DIFF
--- a/resources/views/frontend/opportunity/project/public/completed/index.blade.php
+++ b/resources/views/frontend/opportunity/project/public/completed/index.blade.php
@@ -4,7 +4,7 @@
 <div class="container-fluid" style="min-height: 700px">
   <div class="row">
     <div class="col-xs-12">
-        <h1 class="h3">Current Projects</h1>
+        <h1 class="h3">Past Projects</h1>
     </div>
   </div>
 


### PR DESCRIPTION
A copy/paste error left both project pages with the title 'Current Projects'. Updated the past projects page with the correct title.