### PR TITLE
Update opportunity "Manage" menu action

### DIFF
--- a/resources/views/frontend/opportunity/internship/public/show.blade.php
+++ b/resources/views/frontend/opportunity/internship/public/show.blade.php
@@ -8,9 +8,10 @@
 
             <ul class="nav nav-tabs" style="margin-left: 1em;">
                 <li class="active"><a href="#">View</a></li>
-                @can('manage internship')
+                @can('view admin dashboard')
+                <li><a href="{{ route('admin.opportunity.internship.show', $internship) }}">Manage</a></li>
+                @elsecan('manage internship')
                 <li><a href="{{ route('frontend.opportunity.internship.private.show', $internship) }}">Manage</a></li>
-                {{-- <li><a href="#">Edit</a></li> --}}
                 @endcan
             </ul>
 

--- a/resources/views/frontend/opportunity/project/public/show.blade.php
+++ b/resources/views/frontend/opportunity/project/public/show.blade.php
@@ -8,10 +8,15 @@
 
             <ul class="nav nav-tabs" style="margin-left: 1em;">
                 <li class="active"><a href="#">View</a></li>
-                @can('manage project')
+            @can('view admin dashboard')
+                <li><a href="{{ route('admin.opportunity.project.show', $project) }}">Manage</a></li>
+            @elsecan('manage project')
                 <li><a href="{{ route('frontend.opportunity.project.private.show', $project) }}">Manage</a></li>
+            @endcan
+
+            @can('manage project')
                 <li><a href="{{ route('frontend.opportunity.project.private.edit', $project) }}">Edit</a></li>
-                @endcan
+            @endcan
             </ul>
 
             <div class="col-sm-9">


### PR DESCRIPTION
Public views of projects and internships offer action tabs to go to Edit and Manage views of the opportunity. THis update checks the user's access permissions, if they can access the Admin Dashboard, send them to that view, otherwise users with just lesser management access are sent to frontend dashboard.